### PR TITLE
feat: add icon size variant to Button component

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,10 +1,9 @@
 'use client';
-
 import React from 'react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | 'icon';
   isLoading?: boolean;
 }
 
@@ -18,7 +17,7 @@ export function Button({
   ...props
 }: ButtonProps) {
   const baseStyles = 'inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
-  
+ 
   const variants = {
     primary: 'bg-primary text-white hover:opacity-90 shadow-lg',
     secondary: 'bg-secondary text-white hover:opacity-90',
@@ -30,6 +29,7 @@ export function Button({
     sm: 'px-3 py-1.5 text-sm',
     md: 'px-6 py-3 text-base',
     lg: 'px-8 py-4 text-lg',
+    icon: 'h-10 w-10 p-0', // Added icon size for icon-only buttons
   };
 
   const classes = `${baseStyles} ${variants[variant]} ${sizes[size]} ${isLoading ? 'cursor-not-allowed' : ''} ${className}`;


### PR DESCRIPTION
- Add 'icon' size variant for icon-only buttons
- Maintain all existing functionality and variants
- Support square button layout for navigation controls
- Preserve loading state and accessibility features

Closes #16 